### PR TITLE
Add photo id, citizenship, gender, degree objective field to profiles table

### DIFF
--- a/db/migrate/20190301021316_add_photo_id_data_to_profiles.rb
+++ b/db/migrate/20190301021316_add_photo_id_data_to_profiles.rb
@@ -1,0 +1,9 @@
+class AddPhotoIdDataToProfiles < ActiveRecord::Migration
+  def change
+    add_column :profiles, :photo_id_data, :string
+    add_column :profiles, :citizenship, :string
+    add_column :profiles, :degree_objective_phd, :integer
+    add_column :profiles, :degree_objective_master, :integer
+    add_column :profiles, :gender, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20190223034834) do
+ActiveRecord::Schema.define(version: 20190301021316) do
 
   create_table "admins", force: :cascade do |t|
     t.string   "email",                  default: "", null: false
@@ -99,6 +99,11 @@ ActiveRecord::Schema.define(version: 20190223034834) do
     t.decimal  "gre_writing"
     t.integer  "gre_verbal"
     t.string   "college"
+    t.string   "photo_id_data"
+    t.string   "citizenship"
+    t.integer  "degree_objective_phd"
+    t.integer  "degree_objective_master"
+    t.string   "gender"
   end
 
   add_index "profiles", ["student_id"], name: "index_profiles_on_student_id"


### PR DESCRIPTION
This PR adds photo_id, citizenship, gender and degree objective field to the profile table. The photo_id field was missing from previous PR. Other fields were added from the meeting with Prof last Monday. These fields will be necessary for faculties to evaluate candidates

## Issue Related
#95 

## Code coverage

96.1%
