### PR TITLE
Add Cucumber for admin for student profile

### DIFF
--- a/config/initializers/rails_admin.rb
+++ b/config/initializers/rails_admin.rb
@@ -53,13 +53,16 @@ RailsAdmin.config do |config|
     edit do
       only ['University']
     end
-    bulk_delete
+    bulk_delete do
+      only ['University', 'Faculty', 'Student']
+    end
     approve_faculty do
       only ['Faculty']
     end
     show
-    delete
-
+    delete do
+      only ['University', 'Faculty', 'Student']
+    end
     ## With an audit adapter, you can add:
     # history_index
     # history_show

--- a/config/initializers/rails_admin.rb
+++ b/config/initializers/rails_admin.rb
@@ -59,7 +59,6 @@ RailsAdmin.config do |config|
     end
     show
     delete
-    show_in_app
 
     ## With an audit adapter, you can add:
     # history_index
@@ -68,6 +67,11 @@ RailsAdmin.config do |config|
   config.model 'University' do
     edit do
       exclude_fields :applications
+    end
+  end
+  config.model 'Student' do
+    show do
+      exclude_fields :current_sign_in_ip, :last_sign_in_ip
     end
   end
 end

--- a/features/AdminDashboard.feature
+++ b/features/AdminDashboard.feature
@@ -88,6 +88,10 @@ Feature: Admin can look at all user but cannot edit their information
     When I log in as an admin
     Then I cannot add any profile in the database
 
+  Scenario: Admin cannot edit any profile in the database
+    When I log in as an admin
+    Then I cannot edit any profile in the database
+
   Scenario: Admin cannot export profile data
     When I log in as an admin
     Then I cannot export profile information

--- a/features/AdminDashboard.feature
+++ b/features/AdminDashboard.feature
@@ -2,10 +2,10 @@ Feature: Admin can look at all user but cannot edit their information
 
   Background: I am on the Welcome to Gremester page
     Given the following students have been added to Student Database:
-      | first_name  | last_name  | email          | password  | username          |
-      | Robin       | Hood       | robin@gmail.com  | 12345678    |   robin_hood      |
-      | Thomas      | Edison     | thomas@gmail.com  | 23456789    |   thomas_edison   |
-      | Frank       | Robert     | frank@gmail.com | 34567890    |   frank_robert    |
+      | first_name  | last_name  | email          | password  | username                | id |
+      | Robin       | Hood       | robin@gmail.com  | 12345678    |   robin_hood        | 1  |
+      | Thomas      | Edison     | thomas@gmail.com  | 23456789    |   thomas_edison    | 2  |
+      | Frank       | Robert     | frank@gmail.com | 34567890    |   frank_robert       | 3  |
 
     And the following faculties have been added to Faculty Database:
       | first_name  | last_name   | email             | password    |   username          | weblink |
@@ -17,6 +17,12 @@ Feature: Admin can look at all user but cannot edit their information
       | first_name  | last_name   | email             | password    | password_confirmation |
       | Linh        | Pham         | linh@gmail.com    | 12345689    |  12345689            |
       | Jordan        | Peterson      | jordan@gmail.com   | 23456789    | 23456789         |
+
+    And the following profiles have been added to Profile Database:
+      | student_id    | cgpa   | toefl   | gre_writing    |   gre_verbal  | gre_quant | interested_term | interested_major | college   | year_work_exp | month_work_exp | resume_data | sop_data | additional_attachment_data |
+      | 1             | 3.0    | 100     | 5.0            |   140         | 130       | fall            | Computer Science | Uiowa     | 1             | 4              |             |          |                            |
+      | 2             | 3.2    | 110     | 4.0            |   145         | 150       | fall            | Computer Science | Grinnell  | 2             | 5              |             |          |                            |
+      | 3             | 3.4    | 102     | 4.0            |   130         | 155       | fall            | Computer Science | UMichigan | 0             | 7              |             |          |                            |
 
   Scenario: Admin can see all faculties in the database
     When I log in as an admin
@@ -66,7 +72,6 @@ Feature: Admin can look at all user but cannot edit their information
     When I log in as an admin
     Then I will go to homepage of Gremester if I click on Home button on the navigation bar
 
-
   Scenario: Admin approves faculty once faculty signs up
     When I sign up with valid faculties details
     Then I should see a message saying my account is pending for admin approval
@@ -74,3 +79,15 @@ Feature: Admin can look at all user but cannot edit their information
     Then I can approve the faculty
     Then I can see successful approval message
 
+
+  Scenario: Admin can see all profiles in the database
+    When I log in as an admin
+    Then I can see all profiles in the database
+
+  Scenario: Admin cannot add any profile in the database
+    When I log in as an admin
+    Then I cannot add any profile in the database
+
+  Scenario: Admin cannot export profile data
+    When I log in as an admin
+    Then I cannot export profile information

--- a/features/AdminDashboard.feature
+++ b/features/AdminDashboard.feature
@@ -95,3 +95,7 @@ Feature: Admin can look at all user but cannot edit their information
   Scenario: Admin cannot export profile data
     When I log in as an admin
     Then I cannot export profile information
+
+  Scenario: Admin cannot delete profile data
+    When I log in as an admin
+    Then I cannot delete profile information

--- a/features/step_definitions/admin_steps.rb
+++ b/features/step_definitions/admin_steps.rb
@@ -234,4 +234,10 @@ Then(/^I cannot edit any profile in the database$/) do
   expect(page).to have_no_link('Edit')
 end
 
+Then(/^I cannot delete profile information$/) do
+  visit '/admin/dashboard'
+  find('tr', text: 'Profiles').click_link 'Profiles'
+  expect(page).to have_no_link('Delete')
+end
+
 

--- a/features/step_definitions/admin_steps.rb
+++ b/features/step_definitions/admin_steps.rb
@@ -228,5 +228,10 @@ And(/^I click on log out as an admin$/) do
   click_link 'Log out'
 end
 
+Then(/^I cannot edit any profile in the database$/) do
+  visit '/admin/dashboard'
+  find('tr', text: 'Profiles').click_link 'Profiles'
+  expect(page).to have_no_link('Edit')
+end
 
 

--- a/features/step_definitions/admin_steps.rb
+++ b/features/step_definitions/admin_steps.rb
@@ -121,6 +121,11 @@ Then(/^I can see all (.*?) in the database$/) do |field|
     University.all.each do |university|
       page.should have_content university.university_name
     end
+  elsif field == "profiles"
+    find('tr', text: 'Profiles').click_link 'Profiles'
+    Profile.all.each do |profile|
+      page.should have_content profile.student_id
+    end
   end
 end
 
@@ -131,6 +136,12 @@ Then(/^I cannot edit any student or faculty information$/) do
   visit '/admin/dashboard'
   find('tr', text: 'Students').click_link 'Students'
   expect(page).to have_no_link('Edit')
+end
+
+Then(/^I cannot add any profile in the database$/) do
+  visit '/admin/dashboard'
+  find('tr', text: 'Profiles').click_link 'Profiles'
+  expect(page).to have_no_link('Add new')
 end
 
 Then(/^I can approve faculty credential$/) do
@@ -185,6 +196,9 @@ Then(/^I cannot export (.*?) information$/) do |field|
     expect(page).to have_no_link('Export')
   elsif field.eql?('university')
     find('tr', text: 'Universities').click_link 'Universities'
+    expect(page).to have_no_link('Export')
+  elsif field.eql?('profile')
+    find('tr', text: 'Profiles').click_link 'Profiles'
     expect(page).to have_no_link('Export')
   end
 end


### PR DESCRIPTION
This PR adds Cucumber for admin viewing student profile. Admin should not be able to edit, add new or export profile information


##Issue Related
#84 


## Code coverage
95.53%


