### PR TITLE
Fix issue of generating photo and attached files in production

### DIFF
--- a/app/views/profiles/edit.html.erb
+++ b/app/views/profiles/edit.html.erb
@@ -105,34 +105,46 @@
             <%= text_area :profile, 'month_work_exp', class: "form-control", text: @profile.month_work_exp, id: 'month_work_exp' %>
           </div>
         </div>
+
         <div class="form-group">
           <label class="col-md-3 control-label">SOP:</label>
           <div class="col-md-8">
-            <%if  !@profile.sop.nil? %>
+            <%if !@profile.sop.nil? && Rails.env.production? %>
               <td><%= link_to @profile.sop.metadata['filename'], "#{@profile.sop_url}" %></td>
+            <%elsif !@profile.sop.nil? && Rails.env.development?  %>
+              <td><%= link_to @profile.sop.metadata['filename'], "#{request.base_url + @profile.sop_url}" %></td>
             <%end %>
             <%= f.hidden_field :sop, value: f.object.cached_sop_data %>
             <%= f.file_field :sop, autocomplete: "off" %>
+            <br>
           </div>
         </div>
+
         <div class="form-group">
           <label class="col-md-3 control-label">Resume:</label>
           <div class="col-md-8">
-            <%if  !@profile.resume.nil? %>
+            <% if !@profile.resume.nil? && Rails.env.production? %>
+              <td><%= link_to @profile.resume.metadata['filename'], "#{@profile.resume_url}" %></td>
+            <%elsif !@profile.resume.nil? && Rails.env.development?  %>
               <td><%= link_to @profile.resume.metadata['filename'], "#{request.base_url + @profile.resume_url}" %></td>
-            <%end %>
+            <% end %>
             <%= f.hidden_field :resume, value: f.object.cached_resume_data %>
             <%= f.file_field :resume, autocomplete: "off" %>
+          <br>
           </div>
         </div>
+
         <div class="form-group">
           <label class="col-md-3 control-label">Additional Attachments:</label>
           <div class="col-md-8">
-            <%if  !@profile.additional_attachment.nil? %>
-              <td><%= link_to @profile.additional_attachment.metadata['filename'], "#{request.base_url + @profile.additional_attachment_url}" %></td>
-            <%end %>
+            <%if !@profile.additional_attachment.nil? && Rails.env.production? %>
+              <td><%= link_to @profile.additional_attachment.metadata['filename'], "#{@profile.additional_attachment_url}" %></td>
+            <%elsif !@profile.additional_attachment.nil? && Rails.env.development?  %>
+              <td><%= link_to @profile.resume.metadata['filename'], "#{request.base_url + @profile.additional_attachment_url}" %></td>
+            <% end %>
             <%= f.hidden_field :additional_attachment, value: f.object.cached_additional_attachment_data %>
             <%= f.file_field :additional_attachment, autocomplete: "off" %>
+            <br>
           </div>
         </div>
         <div class="form-group">
@@ -143,7 +155,6 @@
             <%= button_to "Cancel", profiles_path, class:"btn btn-default" %>
           </div>
         </div>
-
       </div>
     </div>
   <%end %>

--- a/app/views/profiles/edit.html.erb
+++ b/app/views/profiles/edit.html.erb
@@ -109,7 +109,7 @@
           <label class="col-md-3 control-label">SOP:</label>
           <div class="col-md-8">
             <%if  !@profile.sop.nil? %>
-              <td><%= link_to @profile.sop.metadata['filename'], "#{request.base_url + @profile.sop_url}" %></td>
+              <td><%= link_to @profile.sop.metadata['filename'], "#{@profile.sop_url}" %></td>
             <%end %>
             <%= f.hidden_field :sop, value: f.object.cached_sop_data %>
             <%= f.file_field :sop, autocomplete: "off" %>

--- a/app/views/profiles/index.html.erb
+++ b/app/views/profiles/index.html.erb
@@ -6,8 +6,8 @@
     <!-- left column -->
     <div class="col-md-3">
       <div class="text-center">
-        <% if @profile.photo_id.present? %>
-          <%= image_tag @profile.photo_id_url, :size => "260x180" %>
+        <% if !@profile.photo_id.nil? %>
+          <%= image_tag @profile.photo_id_url, :size => "120x120" %>
         <% else %>
           <img src="//placehold.it/100" class="avatar img-circle" alt="avatar">
         <%end %>
@@ -19,7 +19,7 @@
       </div>
     </div>
 
-    <!-- edit form column -->
+    <!-- show form column -->
     <div class="col-md-9 personal-info">
 
       <h3>Personal info</h3>
@@ -97,27 +97,35 @@
         <div class="form-group">
           <label class="col-md-3 control-label">SOP:</label>
           <div class="col-md-8">
-            <%if !@profile.sop.nil? %>
+            <%if !@profile.sop.nil? && Rails.env.production? %>
+              <td><%= link_to @profile.sop.metadata['filename'], "#{@profile.sop_url}" %></td>
+            <%elsif !@profile.sop.nil? && Rails.env.development?  %>
               <td><%= link_to @profile.sop.metadata['filename'], "#{request.base_url + @profile.sop_url}" %></td>
             <%end %>
+            <br>
           </div>
 
         </div>
         <div class="form-group">
           <label class="col-md-3 control-label">Resume:</label>
           <div class="col-md-8">
-            <%if  !@profile.resume.nil? %>
-              <td><%= link_to @profile.resume.metadata['filename'], "#{request.base_url + @profile.resume_url}" %></td>
+            <%if  !@profile.resume.nil? && Rails.env.production?  %>
+              <td><%= link_to @profile.resume.metadata['filename'], "#{@profile.resume_url}" %></td>
+            <%elsif !@profile.resume.nil? && Rails.env.development?  %>
+          <td><%= link_to @profile.resume.metadata['filename'], "#{request.base_url + @profile.resume_url}" %></td>
             <% end %>
-
+            <br>
           </div>
         </div>
         <div class="form-group">
           <label class="col-md-3 control-label">Additional Attachments:</label>
           <div class="col-md-8">
-            <%if !@profile.additional_attachment.nil? %>
+            <%if !@profile.additional_attachment.nil? && Rails.env.production? %>
               <td><%= link_to @profile.additional_attachment.metadata['filename'], "#{@profile.additional_attachment_url}" %></td>
+            <%elsif !@profile.additional_attachment.nil? && Rails.env.development?  %>
+          <td><%= link_to @profile.resume.metadata['filename'], "#{request.base_url + @profile.additional_attachment_url}" %></td>
             <% end %>
+            <br>
           </div>
         </div>
         <div class="form-group">

--- a/app/views/profiles/index.html.erb
+++ b/app/views/profiles/index.html.erb
@@ -116,7 +116,7 @@
           <label class="col-md-3 control-label">Additional Attachments:</label>
           <div class="col-md-8">
             <%if !@profile.additional_attachment.nil? %>
-              <td><%= link_to @profile.additional_attachment.metadata['filename'], "#{request.base_url + @profile.additional_attachment_url}" %></td>
+              <td><%= link_to @profile.additional_attachment.metadata['filename'], "#{@profile.additional_attachment_url}" %></td>
             <% end %>
           </div>
         </div>

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -25,7 +25,7 @@ Rails.application.configure do
   config.serve_static_files = ENV['RAILS_SERVE_STATIC_FILES'].present?
 
   # Compress JavaScripts and CSS.
-  config.assets.js_compressor = :uglifier
+  config.assets.js_compressor = Uglifier.new(harmony: true)
   # config.assets.css_compressor = :sass
 
   # Do not fallback to assets pipeline if a precompiled asset is missed.

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -2,7 +2,6 @@
 Rails.application.routes.draw do
   mount RailsAdmin::Engine => '/admin/dashboard', as: 'rails_admin'
   mount ImageUploader.upload_endpoint(:cache) => "/upload"
-  mount DocumentUploader.upload_endpoint(:cache) => "/upload"
   devise_for :students, controllers: {
       sessions: 'students/sessions',
       registrations: 'students/registrations'


### PR DESCRIPTION
This PR fixes #141. @hpitawela has changed permission for google drive storage to allow application to read the file from storage given the correct URL. Now from profile page on Heroku, photo_id and any additional attachment will be generated.

This PR contains some commit messages that are not informative because of debugging on production commits. Once approved, this will be squashed into one commit with meaningful message

## Issue Related

#141 

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Code coverage

96.34%

## Screenshot (if any change in front end)

![image](https://user-images.githubusercontent.com/12748234/53839584-91ac3000-3f5d-11e9-9c7a-53ca9ef7284e.png)

