### PR TITLE
Create a drop down for work experience 

### DIFF
--- a/app/controllers/profiles_controller.rb
+++ b/app/controllers/profiles_controller.rb
@@ -1,6 +1,6 @@
 class ProfilesController < ApplicationController
   def profile_params
-    params.require(:profile).permit(:id, :photo_id, :sop, :resume, :additional_attachment, :cgpa, :toefl, :gre_writing, :gre_verbal, :gre_quant, :interested_major, :interested_term, :interested_year, :year_work_exp, :month_work_exp)
+    params.require(:profile).permit(:id, :photo_id, :sop, :resume, :additional_attachment, :cgpa, :toefl, :gre_writing, :gre_verbal, :gre_quant, :interested_major, :interested_term, :interested_year)
   end
 
   def index
@@ -43,7 +43,7 @@ class ProfilesController < ApplicationController
                               :gre_quant => params[:gre_quant], :gre_verbal => params[:gre_verbal], :gre_writing => params[:gre_writing],
                               :interested_major => params[:interested_major], :interested_year => params[:interested_year],
                               :interested_term => params[:interested_term], :year_work_exp => params[:year_work_exp],
-                              :month_work_exp => params[:month_work_exp], :resume => params[:resume], :sop => params[:sop],
+                              :resume => params[:resume], :sop => params[:sop],
                               :additional_attachment => params[:additional_attachment], :student_id => current_student.id)
     if !@profile.errors.full_messages.empty?
       error = ''
@@ -69,8 +69,9 @@ class ProfilesController < ApplicationController
     @interested_major = profile_params[:interested_major]
     @interested_term = profile_params[:interested_term]
     @interested_year = profile_params[:interested_year]
-    @year_work_exp = profile_params[:year_work_exp]
-    @month_work_exp = profile_params[:month_work_exp]
+    @year_work_exp = params[:year_work_exp]
+    puts 'here'
+    puts @year_work_exp
     @profile = current_student.current_profile
     @profile.update_cgpa(@gpa.to_f) if !@gpa.blank?
     @profile.update_toefl(@toefl.to_i)  if !@toefl.blank?
@@ -80,8 +81,7 @@ class ProfilesController < ApplicationController
     @profile.update_interested_major(@interested_major) if !@interested_major.blank?
     @profile.update_interested_term(@interested_term)  if !@interested_term.blank?
     @profile.update_interested_year(@interested_year)  if !@interested_year.blank?
-    @profile.update_year_work_experience(@year_work_exp.to_i)  if !@year_work_exp.blank?
-    @profile.update_month_work_experience(@month_work_exp.to_i)  if !@month_work_exp.blank?
+    @profile.update_year_work_experience(@year_work_exp)  if !@year_work_exp.blank?
     @profile.photo_id = profile_params[:photo_id]
     @profile.sop = profile_params[:sop]
     @profile.resume = profile_params[:resume]

--- a/app/models/profile.rb
+++ b/app/models/profile.rb
@@ -17,8 +17,6 @@ class Profile < ActiveRecord::Base
   validates_inclusion_of :gre_writing, :in => 0..6, allow_blank: true, message: 'must be within the range from 0 to 6.0'
   validates_inclusion_of :toefl, :in => 0..120, allow_blank: true, message: 'must be within the range from 0 to 120'
   validates_numericality_of :cgpa, :greater_than_or_equal_to => 0, allow_blank: true, message: 'must be greater than or equal to 0'
-  validates_numericality_of :year_work_exp, :greater_than_or_equal_to => 0, allow_blank: true, message: 'must be greater than or equal to 0'
-  validates_numericality_of :month_work_exp, :greater_than_or_equal_to => 0, allow_blank: true, message: 'must be greater than or equal to 0'
   validates_presence_of :student_id
 
 
@@ -59,9 +57,6 @@ class Profile < ActiveRecord::Base
     self.year_work_exp = year_work_exp
   end
 
-  def update_month_work_experience(month_work_exp)
-    self.month_work_exp = month_work_exp
-  end
 
   def update_resume_data(resume_data)
     self.resume_data = resume_data

--- a/app/views/profiles/edit.html.erb
+++ b/app/views/profiles/edit.html.erb
@@ -145,14 +145,8 @@
         <div class="form-group">
           <label class="col-md-3 control-label">Work Experience (Year):</label>
           <div class="col-md-8">
-            <%= text_area :profile, 'year_work_exp', class: "form-control", text: @profile.year_work_exp, id: 'year_work_exp'   %>
-          </div>
-        </div>
-
-        <div class="form-group">
-          <label class="col-md-3 control-label">Work Experience (Month):</label>
-          <div class="col-md-8">
-            <%= text_area :profile, 'month_work_exp', class: "form-control", text: @profile.month_work_exp, id: 'month_work_exp' %>
+            <%= select_tag "year_work_exp", options_for_select(['Less than 1 year', '1 - 2 years', '3 - 4 years', '4 - 5 years', '5 - 7 years', '7 - 10 years', '>10 years', 'Not Specified']), include_blank: 'Estimate year of work experience', class: "form-control" %>
+            <br>
           </div>
         </div>
 

--- a/app/views/profiles/show.html.erb
+++ b/app/views/profiles/show.html.erb
@@ -149,7 +149,7 @@
         <div class="form-group">
           <label class="col-md-3 control-label">Work Experience:</label>
           <div class="col-md-8">
-            <input class="form-control" type="text" value="Years: <%= @profile.year_work_exp %> Months: <%= @profile.month_work_exp %>" readonly>
+            <input class="form-control" type="text" value=" <%= @profile.year_work_exp %>" readonly>
           </div>
         </div>
         <div class="form-group">

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -33,7 +33,6 @@ en:
         gre_writing: "GRE Writing Score"
         toefl: "TOEFL Score"
         year_work_exp: "Years of working experience"
-        month_work_exp: "Months of working experience"
         cgpa: "GPA"
 
 

--- a/db/migrate/20190313183913_remove_months_work_experience_from_profile.rb
+++ b/db/migrate/20190313183913_remove_months_work_experience_from_profile.rb
@@ -1,0 +1,7 @@
+class RemoveMonthsWorkExperienceFromProfile < ActiveRecord::Migration
+  def change
+    remove_column :profiles, :month_work_exp
+    remove_column :profiles, :year_work_exp
+    add_column :profiles, :year_work_exp, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20190312193835) do
+ActiveRecord::Schema.define(version: 20190313183913) do
 
   create_table "admins", force: :cascade do |t|
     t.string   "email",                  default: "", null: false
@@ -117,8 +117,6 @@ ActiveRecord::Schema.define(version: 20190312193835) do
     t.string   "interested_major"
     t.string   "interested_term"
     t.integer  "interested_year"
-    t.integer  "year_work_exp"
-    t.integer  "month_work_exp"
     t.text     "resume_data"
     t.text     "sop_data"
     t.text     "additional_attachment_data"
@@ -131,6 +129,7 @@ ActiveRecord::Schema.define(version: 20190312193835) do
     t.integer  "degree_objective_master"
     t.string   "gender"
     t.integer  "grading_scale_type_id"
+    t.string   "year_work_exp"
   end
 
   add_index "profiles", ["country_id"], name: "index_profiles_on_country_id"

--- a/features/AdminDashboard.feature
+++ b/features/AdminDashboard.feature
@@ -19,10 +19,10 @@ Feature: Admin can look at all user but cannot edit their information
       | Jordan        | Peterson      | jordan@gmail.com   | 23456789    | 23456789         |
 
     And the following profiles have been added to Profile Database:
-      | student_id    | cgpa   | toefl   | gre_writing    |   gre_verbal  | gre_quant | interested_term | interested_major | year_work_exp | month_work_exp | resume_data | sop_data | additional_attachment_data |
-      | 1             | 3.0    | 100     | 5.0            |   140         | 130       | fall            | Computer Science |  1             | 4              |             |          |                            |
-      | 2             | 3.2    | 110     | 4.0            |   145         | 150       | fall            | Computer Science |  2             | 5              |             |          |                            |
-      | 3             | 3.4    | 102     | 4.0            |   130         | 155       | fall            | Computer Science |  0             | 7              |             |          |                            |
+      | student_id    | cgpa   | toefl   | gre_writing    |   gre_verbal  | gre_quant | interested_term | interested_major | year_work_exp | resume_data | sop_data | additional_attachment_data |
+      | 1             | 3.0    | 100     | 5.0            |   140         | 130       | fall            | Computer Science |  1             |            |          |                            |
+      | 2             | 3.2    | 110     | 4.0            |   145         | 150       | fall            | Computer Science |  2             |              |          |                            |
+      | 3             | 3.4    | 102     | 4.0            |   130         | 155       | fall            | Computer Science |  0             |             |          |                            |
 
     And the following universities have been added to University Database:
       |id| rank   | university_name  | university_type | acceptance_rate | tuition |location|weather|university_link|university_desc|

--- a/features/Profile.feature
+++ b/features/Profile.feature
@@ -35,10 +35,10 @@ Feature: Allow students to edit their profile
 
 
     And the following profiles have been added to Profile Database:
-      | student_id    | cgpa   | toefl   | gre_writing    |   gre_verbal  | gre_quant | interested_term | interested_major |  year_work_exp | month_work_exp | resume_data | sop_data | additional_attachment_data |
-      | 1             | 3.0    | 100     | 5.0            |   140         | 130       | fall            | Computer Science |  1             | 4              |             |          |                            |
-      | 2             | 3.2    | 110     | 4.0            |   145         | 150       | fall            | Computer Science |  2             | 5              |             |          |                            |
-      | 3             | 3.4    | 102     | 4.0            |   130         | 155       | fall            | Computer Science |  0             | 7              |             |          |                            |
+      | student_id    | cgpa   | toefl   | gre_writing    |   gre_verbal  | gre_quant | interested_term | interested_major |  year_work_exp |resume_data  | sop_data | additional_attachment_data |
+      | 1             | 3.0    | 100     | 5.0            |   140         | 130       | fall            | Computer Science |  1             |             |          |                            |
+      | 2             | 3.2    | 110     | 4.0            |   145         | 150       | fall            | Computer Science |  2             |             |          |                            |
+      | 3             | 3.4    | 102     | 4.0            |   130         | 155       | fall            | Computer Science |  0             |             |          |                            |
 
   Scenario: Students can update their name
     When I log in as a student

--- a/features/UpdateApplicationStatus.feature
+++ b/features/UpdateApplicationStatus.feature
@@ -8,10 +8,10 @@ Feature: Allow students to add school to list of potential schools and update st
       | Frank       | Robert     | frank@gmail.com | 34567890    |   frank_robert    | 2019-02-15 02:46:01 UTC    |3  |
 
     And the following profiles have been added to Profile Database:
-      | student_id    | cgpa   | toefl   | gre_writing    |   gre_verbal  | gre_quant | interested_term | interested_major |  year_work_exp | month_work_exp | resume_data | sop_data | additional_attachment_data | id |
-      | 1             | 3.0    | 100     | 5.0            |   140         | 130       | fall            | Computer Science |  1             | 4              | test resume | test sop | test additional            | 1  |
-      | 2             | 3.2    | 110     | 4.0            |   145         | 150       | fall            | Computer Science |  2             | 5              | test resume | test sop | test additional            | 2  |
-      | 3             | 3.4    | 102     | 4.0            |   130         | 155       | fall            | Computer Science |  0             | 7              | test resume | test sop | test additional            | 3  |
+      | student_id    | cgpa   | toefl   | gre_writing    |   gre_verbal  | gre_quant | interested_term | interested_major |  year_work_exp |  resume_data | sop_data | additional_attachment_data | id |
+      | 1             | 3.0    | 100     | 5.0            |   140         | 130       | fall            | Computer Science |  1             |  test resume | test sop | test additional            | 1  |
+      | 2             | 3.2    | 110     | 4.0            |   145         | 150       | fall            | Computer Science |  2             |  test resume | test sop | test additional            | 2  |
+      | 3             | 3.4    | 102     | 4.0            |   130         | 155       | fall            | Computer Science |  0             |  test resume | test sop | test additional            | 3  |
 
     And the following universities have been added to University Database:
       | rank  | university_name                     | university_type | acceptance_rate | tuition |location     |weather|university_link|university_desc|

--- a/features/step_definitions/students_steps.rb
+++ b/features/step_definitions/students_steps.rb
@@ -195,11 +195,9 @@ Then /^I can update my (.*?)$/ do |field|
     current_student.current_profile.interested_term.should eq('Spring')
     current_student.current_profile.interested_year.should eq(2022)
   when 'work experience'
-    fill_in 'year_work_exp', with: '10'
-    fill_in 'month_work_exp', with: '12'
+    select('>10 years', from: 'year_work_exp')
     click_button 'Save Changes'
-    current_student.current_profile.year_work_exp.should eq(10)
-    current_student.current_profile.month_work_exp.should eq(12)
+    current_student.current_profile.year_work_exp.should eq(">10 years")
   when 'last name and first name'
     fill_in 'first_name', with: 'Linh'
     fill_in 'last_name', with: 'Pham'

--- a/spec/controllers/profiles_controller_spec.rb
+++ b/spec/controllers/profiles_controller_spec.rb
@@ -42,12 +42,12 @@ describe ProfilesController do
       controller.instance_eval {@profile = @mock_profile}
     end
     it 'should redirect to profile on successful update' do
-      post :update, {"profile"=>{"photo_id"=>"", "college"=>"uiowa", "cgpa"=>"3.4", "toefl"=>"110", "gre_writing"=>"4.0", "gre_quant"=>"130", "gre_verbal"=>"140", "interested_major"=>"", "interested_term"=>"", "interested_year"=>"", "year_work_exp"=>"", "month_work_exp"=>"", "sop"=>"", "resume"=>"", "additional_attachment"=>""}, "current_student"=>{"first_name"=>"Avanti", "last_name"=>"Deshmukh"}, "id"=>1, "citizenship" => 1, "grading_scale" => "test", "undergrad_universities" => 1, "research_interest" => [1]}
+      post :update, {"profile"=>{"photo_id"=>"", "college"=>"uiowa", "cgpa"=>"3.4", "toefl"=>"110", "gre_writing"=>"4.0", "gre_quant"=>"130", "gre_verbal"=>"140", "interested_major"=>"", "interested_term"=>"", "interested_year"=>"", "year_work_exp"=>"", "sop"=>"", "resume"=>"", "additional_attachment"=>""}, "current_student"=>{"first_name"=>"Avanti", "last_name"=>"Deshmukh"}, "id"=>1, "citizenship" => 1, "grading_scale" => "test", "undergrad_universities" => 1, "research_interest" => [1]}
       response.should redirect_to(profile_path)
     end
 
     it 'should stay on same page on unsuccessful update' do
-      post :update, {"profile"=>{"photo_id"=>"", "college"=>"uiowa", "cgpa"=>"3.4", "toefl"=>"110", "gre_writing"=>"9.0", "gre_quant"=>"890", "gre_verbal"=>"140", "interested_major"=>"", "interested_term"=>"", "interested_year"=>"", "year_work_exp"=>"", "month_work_exp"=>"", "sop"=>"", "resume"=>"", "additional_attachment"=>""}, "current_student"=>{"first_name"=>"Avanti", "last_name"=>"Deshmukh"}, "id"=>1}
+      post :update, {"profile"=>{"photo_id"=>"", "college"=>"uiowa", "cgpa"=>"3.4", "toefl"=>"110", "gre_writing"=>"9.0", "gre_quant"=>"890", "gre_verbal"=>"140", "interested_major"=>"", "interested_term"=>"", "interested_year"=>"", "year_work_exp"=>"", "sop"=>"", "resume"=>"", "additional_attachment"=>""}, "current_student"=>{"first_name"=>"Avanti", "last_name"=>"Deshmukh"}, "id"=>1}
       response.should render_template('edit')
     end
 

--- a/spec/models/profile_spec.rb
+++ b/spec/models/profile_spec.rb
@@ -10,8 +10,6 @@ RSpec.describe Profile, type: :model do
   it { should validate_inclusion_of(:gre_writing).in_range(0..6).with_message("must be within the range from 0 to 6.0")}
   it { should validate_inclusion_of(:toefl).in_range(0..120).with_message("must be within the range from 0 to 120")}
   it { should validate_numericality_of(:cgpa).is_greater_than_or_equal_to(0).with_message("must be greater than or equal to 0")}
-  it { should validate_numericality_of(:year_work_exp).is_greater_than_or_equal_to(0).with_message("must be greater than or equal to 0")}
-  it { should validate_numericality_of(:month_work_exp).is_greater_than_or_equal_to(0).with_message("must be greater than or equal to 0")}
 
   context "Updating profile field" do
     it "should update gre quant field of the profile" do
@@ -52,14 +50,6 @@ RSpec.describe Profile, type: :model do
       mock_profile.update_cgpa(4.0)
       student.profile = mock_profile
       assert(student.current_profile.cgpa).eql?(4.0)
-    end
-    #
-    it "should update month of exeprience field of the profile" do
-      student = Student.new(id: 1, first_name: 'John', last_name: 'Doe', email: 'john@example.com', password: 'test12345', username: 'test')
-      mock_profile = Profile.new(gre_quant: 150, gre_verbal: 130, gre_writing: 3.0, toefl: 100, cgpa: 3.4, interested_major: 'Computer Science', interested_term: 'fall', interested_year: 2019, month_work_exp: 4)
-      mock_profile.update_month_work_experience(12)
-      student.profile = mock_profile
-      assert(student.current_profile.month_work_exp).eql?(12)
     end
 
     it "should update year of experience field of the profile" do

--- a/spec/models/research_interest_spec.rb
+++ b/spec/models/research_interest_spec.rb
@@ -2,6 +2,5 @@ require 'rails_helper'
 
 
 RSpec.describe ResearchInterest, type: :model do
-
   it { should have_many(:profiles).through(:research_interests_profiles) }
 end


### PR DESCRIPTION
This PR removes month of experience field from the profile table and populates the dropdown for years of work experience in the edit profile page


## Issue Related

#166 
## Type of change
- [x] New feature (non-breaking change which adds functionality)
- [x] Front end change

## Code coverage

93.79%

## Screenshot (if any change in front end)

![image](https://user-images.githubusercontent.com/12748234/54323651-3e268b80-45c8-11e9-8356-5ec82232d0a3.png)

