### PR TITLE
Generate photo id of faculties on admin dashboard

### DIFF
--- a/app/views/share/_image_preview.html.erb
+++ b/app/views/share/_image_preview.html.erb
@@ -1,0 +1,2 @@
+
+<%= image_tag local_assigns[:url], :size => "260x180" %>

--- a/config/application.rb
+++ b/config/application.rb
@@ -5,7 +5,7 @@ require 'rails/all'
 # Require the gems listed in Gemfile, including any gems
 # you've limited to :test, :development, or :production.
 Bundler.require(*Rails.groups)
-
+require_relative './initializers/shrine'
 module Masterapp
   class Application < Rails::Application
     config.assets.enabled = true

--- a/config/initializers/rails_admin.rb
+++ b/config/initializers/rails_admin.rb
@@ -86,7 +86,6 @@ RailsAdmin.config do |config|
       field :id_card_data do
         formatted_value do
           bindings[:view].render :partial => 'share/image_preview',  locals: {field: self, form: bindings[:form], url: bindings[:object].id_card_url}
-          # bindings[:view].tag(:img, { :src => bindings[:object].id_card_url(:thumb) })
         end
       end
     end
@@ -95,7 +94,6 @@ RailsAdmin.config do |config|
         field :id_card_data do
           formatted_value do
             bindings[:view].render :partial => 'share/image_preview',  locals: {field: self, form: bindings[:form], url: bindings[:object].id_card_url}
-            # bindings[:view].tag(:img, { :src => bindings[:object].id_card_url(:thumb) })
           end
         end
       end

--- a/config/initializers/rails_admin.rb
+++ b/config/initializers/rails_admin.rb
@@ -80,4 +80,24 @@ RailsAdmin.config do |config|
 
   config.excluded_models = ["ResearchInterestsProfile", "ProfilesUndergradUniversity"]
 
-end
+  config.model Faculty do
+    list do
+      include_fields :first_name, :last_name, :email, :weblink, :university, :username
+      field :id_card_data do
+        formatted_value do
+          bindings[:view].render :partial => 'share/image_preview',  locals: {field: self, form: bindings[:form], url: bindings[:object].id_card_url}
+          # bindings[:view].tag(:img, { :src => bindings[:object].id_card_url(:thumb) })
+        end
+      end
+    end
+      show do
+        include_fields :first_name, :last_name, :email, :weblink, :university, :username
+        field :id_card_data do
+          formatted_value do
+            bindings[:view].render :partial => 'share/image_preview',  locals: {field: self, form: bindings[:form], url: bindings[:object].id_card_url}
+            # bindings[:view].tag(:img, { :src => bindings[:object].id_card_url(:thumb) })
+          end
+        end
+      end
+    end
+  end

--- a/features/step_definitions/admin_steps.rb
+++ b/features/step_definitions/admin_steps.rb
@@ -37,7 +37,7 @@ Given(/the following (.*?) have been added to (.*?) Database:/) do |user, table_
       Profile.create(profile)
     end
   when 'Country'
-     user_table.hashes.each do |country|
+    user_table.hashes.each do |country|
       Country.create(country)
     end
   when 'Application'
@@ -231,12 +231,7 @@ end
 Then(/^I can open weblink to validate faculty's credential$/) do
   visit '/admin/dashboard'
   find('tr', text: 'Faculties').click_link 'Faculties'
-  if !page.has_link?('http://homepage.cs.uiowa.edu/~alicem/')
-    find('tr', text: 'alicen@uiowa.edu').click_link('...')
-    expect(page).to have_content('http://homepage.cs.uiowa.edu/~alicem/')
-  else
-    expect(page).to have_content('http://homepage.cs.uiowa.edu/~alicem/')
-  end
+  expect(page).to have_content('http://homepage.cs.uiowa.edu/~alicem/')
 end
 
 Then(/^I will go to homepage of Gremester if I click on Home button on the navigation bar$/) do


### PR DESCRIPTION
This PR includes implementation to allow admins to see the photo_id picture of faculties. Before, it only showed metadata of the file.

## Type of change

- [x] New feature (non-breaking change which adds functionality)

## Code coverage
97.1%

## Screenshot (if any change in front end)
![image](https://user-images.githubusercontent.com/12748234/54580795-c2697c00-49d7-11e9-93ea-d737e896f4ce.png)
