### PR TITLE
Implementation to not allow users to add universities if already existed in database

### DIFF
--- a/app/assets/javascripts/edit_profile.js
+++ b/app/assets/javascripts/edit_profile.js
@@ -106,15 +106,20 @@ $(document).ready(function () {
         var website = $('#undergrad_website_text').val();
         var new_rank_type = $('#new_rank_type').val();
         var valid = true;
-        if (school_name === '') {
+        if (school_name == null || school_name.length === 0) {
             $("div[role=alert]").text('');
             $("div[role=alert]").text('Please fill in university name');
             $("div[role=alert]").show();
             valid = false;
-        } else if (ranking !== '') {
-            if (rank_type === null) {
+        } else if (ranking !== null && ranking.length > 0) {
+            if (rank_type == null || rank_type.length === 0) {
                 $("div[role=alert]").text('');
                 $("div[role=alert]").text('Please select rank type');
+                $("div[role=alert]").show();
+                valid = false;
+            } else if (rank_type === 'Ranking type not listed' && (new_rank_type === null || new_rank_type.length === 0)) {
+                $("div[role=alert]").text('');
+                $("div[role=alert]").text('Please specify new rank type');
                 $("div[role=alert]").show();
                 valid = false;
             } else {
@@ -124,14 +129,20 @@ $(document).ready(function () {
                     $("div[role=alert]").text('Ranking must be a number greater than 0');
                     $("div[role=alert]").show();
                     valid = false;
-
                 }
             }
-        } else if (acceptance_rate !== '') {
+        } else if (acceptance_rate !== null && acceptance_rate.length > 0) {
             var acceptance_rate_num = parseInt(acceptance_rate, 10);
             if (isNaN(acceptance_rate_num) || acceptance_rate_num < 0 || acceptance_rate_num > 100) {
                 $("div[role=alert]").text('');
                 $("div[role=alert]").text('Acceptance rate must be a number greater than 0 and less than 100');
+                $("div[role=alert]").show();
+                valid = false;
+            }
+        } else if (rank_type !== null && rank_type.length > 0) {
+            if (ranking == null || ranking.length === 0) {
+                $("div[role=alert]").text('');
+                $("div[role=alert]").text('Please specify ranking');
                 $("div[role=alert]").show();
                 valid = false;
             }
@@ -151,11 +162,17 @@ $(document).ready(function () {
                     university_link: website,
                     new_rank_type: new_rank_type
                 },
-                dataType: 'html',
+                dataType: 'json',
                 success: function (data) {
-                    setTimeout(function () {
-                        window.location.reload();
-                    });
+                    if (data.errors != null) {
+                        $("div[role=alert]").text('');
+                        $("div[role=alert]").text(data.errors);
+                        $("div[role=alert]").show();
+                    } else {
+                        setTimeout(function () {
+                            window.location.reload();
+                        });
+                    }
 
                 },
 

--- a/app/models/undergrad_university.rb
+++ b/app/models/undergrad_university.rb
@@ -4,4 +4,5 @@ class UndergradUniversity < ActiveRecord::Base
   has_many :profiles_undergrad_universities
   has_many :profiles, through: :profiles_undergrad_universities
   has_and_belongs_to_many :profiles
+  validates_uniqueness_of :university_name, scope: :country_id
 end

--- a/db/migrate/20190320033749_remove_undergrad_index.rb
+++ b/db/migrate/20190320033749_remove_undergrad_index.rb
@@ -1,0 +1,6 @@
+class RemoveUndergradIndex < ActiveRecord::Migration
+  def change
+    remove_index(:undergrad_universities, :name => "index_undergrad_universities_on_university_name")
+    add_index :undergrad_universities, [:country_id, :university_name], unique: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20190313183913) do
+ActiveRecord::Schema.define(version: 20190320033749) do
 
   create_table "admins", force: :cascade do |t|
     t.string   "email",                  default: "", null: false
@@ -208,9 +208,9 @@ ActiveRecord::Schema.define(version: 20190313183913) do
     t.datetime "updated_at",      null: false
   end
 
+  add_index "undergrad_universities", ["country_id", "university_name"], name: "index_undergrad_universities_on_country_id_and_university_name", unique: true
   add_index "undergrad_universities", ["country_id"], name: "index_undergrad_universities_on_country_id"
   add_index "undergrad_universities", ["ranking_id"], name: "index_undergrad_universities_on_ranking_id"
-  add_index "undergrad_universities", ["university_name"], name: "index_undergrad_universities_on_university_name", unique: true
 
   create_table "universities", force: :cascade do |t|
     t.integer "rank"

--- a/spec/controllers/undergrad_universities_controller_spec.rb
+++ b/spec/controllers/undergrad_universities_controller_spec.rb
@@ -15,7 +15,6 @@ describe UndergradUniversitiesController do
       UndergradUniversity.create(country_id: 2, university_name: 'University of Iowa')
       RankType.create(id: 3, name: 'world rank')
       @undergrad = UndergradUniversity.new
-      request.env['HTTP_REFERER'] = 'http://localhost:3000/profiles/1/edit?'
       @before_count = UndergradUniversity.count
     end
   it 'should save the university details on successful update' do


### PR DESCRIPTION
This PR adds implementation to return a form error if students attempt to add university or new rank type that already in the database.

## Issue Related
#136 

## Type of change

- [x] New feature (non-breaking change which adds functionality)
- [x] Front end change

## Code coverage
97.2%

## Screenshot (if any change in front end)
![image](https://user-images.githubusercontent.com/12748234/54662205-417bb480-4aab-11e9-93be-b3d3b26a15e4.png)

![image](https://user-images.githubusercontent.com/12748234/54662221-56f0de80-4aab-11e9-8e2f-08a52de48d41.png)

