### PR TITLE
Fix devise vulnerability issue

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,6 +1,5 @@
 ruby '2.4.4'
 source 'https://rubygems.org'
-
 # Bundle edge Rails instead: gem 'rails', github: 'rails/rails'
 gem 'rails', '4.2.11'
 gem 'jasmine'
@@ -16,7 +15,7 @@ gem 'coffee-rails', '~> 4.1.0'
 # See https://github.com/rails/execjs#readme for more supported runtimes
 # gem 'therubyracer', platforms: :ruby
 # Use devise for storing password and authentication
-gem 'devise', '~> 3.4.0'
+gem "devise", ">= 4.6.0"
 # Use bcrypt for password encryption
 gem 'bcrypt'
 gem 'bootstrap-datepicker-rails'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -39,13 +39,13 @@ GEM
     addressable (2.6.0)
       public_suffix (>= 2.0.2, < 4.0)
     arel (6.0.4)
-    backports (3.11.4)
+    backports (3.12.0)
     bcrypt (3.1.12)
     bootstrap-datepicker-rails (1.8.0.1)
       railties (>= 3.0)
     builder (3.2.3)
-    byebug (11.0.0)
-    capybara (3.13.2)
+    byebug (11.0.1)
+    capybara (3.15.0)
       addressable
       mini_mime (>= 0.1.3)
       nokogiri (~> 1.8)
@@ -63,7 +63,7 @@ GEM
       execjs
     coffee-script-source (1.12.2)
     commonjs (0.2.7)
-    concurrent-ruby (1.1.4)
+    concurrent-ruby (1.1.5)
     connection_pool (2.2.2)
     content_disposition (1.0.0)
     crass (1.0.4)
@@ -93,20 +93,19 @@ GEM
     debug_inspector (0.0.3)
     declarative (0.0.10)
     declarative-option (0.1.0)
-    devise (3.4.1)
+    devise (4.6.1)
       bcrypt (~> 3.0)
       orm_adapter (~> 0.1)
-      railties (>= 3.2.6, < 5)
+      railties (>= 4.1.0, < 6.0)
       responders
-      thread_safe (~> 0.1)
       warden (~> 1.2.3)
     diff-lcs (1.3)
     digest-crc (0.4.1)
     docile (1.3.1)
-    dotenv (2.6.0)
-    dotenv-rails (2.6.0)
-      dotenv (= 2.6.0)
-      railties (>= 3.2, < 6.0)
+    dotenv (2.7.1)
+    dotenv-rails (2.7.1)
+      dotenv (= 2.7.1)
+      railties (>= 3.2, < 6.1)
     down (4.8.0)
       addressable (~> 2.5)
     erubis (2.7.0)
@@ -118,7 +117,7 @@ GEM
     factory_girl_rails (4.9.0)
       factory_girl (~> 4.9.0)
       railties (>= 3.0.0)
-    faker (1.9.1)
+    faker (1.9.3)
       i18n (>= 0.7)
     faraday (0.15.4)
       multipart-post (>= 1.2, < 3)
@@ -275,7 +274,7 @@ GEM
       coderay (~> 1.1.0)
       method_source (~> 0.9.0)
     public_suffix (3.0.3)
-    puma (3.12.0)
+    puma (3.12.1)
     pusher-client (0.6.2)
       json
       websocket (~> 1.0)
@@ -387,7 +386,7 @@ GEM
     shellany (0.0.1)
     shoulda-matchers (3.1.3)
       activesupport (>= 4.0.0)
-    shrine (2.15.0)
+    shrine (2.16.0)
       content_disposition (~> 1.0)
       down (~> 4.1)
     shrine-google_cloud_storage (2.0.0)
@@ -413,7 +412,7 @@ GEM
       activesupport (>= 4.0)
       sprockets (>= 3.0.0)
     sqlite3 (1.3.13)
-    temple (0.8.0)
+    temple (0.8.1)
     therubyracer (0.12.3)
       libv8 (~> 3.16.14.15)
       ref
@@ -469,7 +468,7 @@ DEPENDENCIES
   coffee-rails (~> 4.1.0)
   cucumber-rails
   database_cleaner
-  devise (~> 3.4.0)
+  devise (>= 4.6.0)
   dotenv-rails
   factory_girl
   factory_girl_rails
@@ -509,9 +508,3 @@ DEPENDENCIES
   twitter-bootswatch-rails-helpers
   uglifier (>= 2.7.0)
   web-console
-
-RUBY VERSION
-   ruby 2.4.4p296
-
-BUNDLED WITH
-   1.17.3

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -6,7 +6,7 @@ class ApplicationController < ActionController::Base
   before_action :configure_permitted_parameters, if: :devise_controller?
 
   def configure_permitted_parameters
-    devise_parameter_sanitizer.for(:sign_up) { |u| u.permit(:first_name, :last_name, :username, :email, :password, :password_confirmation, :id_card, :weblink, :university_id) }
+    devise_parameter_sanitizer.permit(:sign_up, keys: [:first_name, :last_name, :username, :email, :password, :password_confirmation, :id_card, :weblink, :university_id])
   end
   protected
 

--- a/features/step_definitions/students_steps.rb
+++ b/features/step_definitions/students_steps.rb
@@ -126,7 +126,7 @@ When /^I log in with wrong (.*?) email/ do |field|
 end
 
 Then /^I should see an invalid login message/ do
-  page.should have_content "Invalid email or password"
+  page.should have_content "Invalid Email or password"
 end
 
 When /^I log in with wrong (.*?) password/ do |field|


### PR DESCRIPTION
This PR fixes the vulnerability alert with Devise on Github. We need to change the Devise version and it might require us to change local bundler version to be < 2.0.0. If bundle install gives bundler error with this change, please try the following commands:

gem uninstall bundler
gem install bundler --version '1.9.9'
gem install

