### PR TITLE
Modify start term and year select into a dropdown on edit profile page

### DIFF
--- a/app/controllers/profiles_controller.rb
+++ b/app/controllers/profiles_controller.rb
@@ -1,6 +1,6 @@
 class ProfilesController < ApplicationController
   def profile_params
-    params.require(:profile).permit(:id, :photo_id, :sop, :resume, :additional_attachment, :cgpa, :toefl, :gre_writing, :gre_verbal, :gre_quant, :interested_major, :interested_term, :interested_year)
+    params.require(:profile).permit(:id, :photo_id, :sop, :resume, :additional_attachment, :cgpa, :toefl, :gre_writing, :gre_verbal, :gre_quant, :interested_major, :interested_year)
   end
 
   def index
@@ -47,7 +47,7 @@ class ProfilesController < ApplicationController
     @gre_quant = profile_params[:gre_quant]
     @gre_verbal = profile_params[:gre_verbal]
     @interested_major = profile_params[:interested_major]
-    @interested_term = profile_params[:interested_term]
+    @interested_term = params[:interested_term]
     @interested_year = profile_params[:interested_year]
     @year_work_exp = params[:year_work_exp]
     @profile = current_student.current_profile

--- a/app/controllers/profiles_controller.rb
+++ b/app/controllers/profiles_controller.rb
@@ -1,6 +1,6 @@
 class ProfilesController < ApplicationController
   def profile_params
-    params.require(:profile).permit(:id, :photo_id, :sop, :resume, :additional_attachment, :cgpa, :toefl, :gre_writing, :gre_verbal, :gre_quant, :interested_major, :interested_year)
+    params.require(:profile).permit(:id, :photo_id, :sop, :resume, :additional_attachment, :cgpa, :toefl, :gre_writing, :gre_verbal, :gre_quant, :interested_major)
   end
 
   def index
@@ -48,7 +48,7 @@ class ProfilesController < ApplicationController
     @gre_verbal = profile_params[:gre_verbal]
     @interested_major = profile_params[:interested_major]
     @interested_term = params[:interested_term]
-    @interested_year = profile_params[:interested_year]
+    @interested_year = params[:interested_year]
     @year_work_exp = params[:year_work_exp]
     @profile = current_student.current_profile
     @profile.update_cgpa(@gpa.to_f) if !@gpa.blank?
@@ -83,8 +83,18 @@ class ProfilesController < ApplicationController
     end
 
     if !params[:research_interest].blank?
+      has_interest = false
+      all_student_interests = @profile.research_interests
       params[:research_interest].each  do |interest|
-        @profile.research_interests << ResearchInterest.find_by_id(interest.to_i)
+        all_student_interests.each do |i|
+          if i.id.eql?(interest.to_i)
+            has_interest = true
+          end
+        end
+        if !has_interest
+          all_student_interests << ResearchInterest.find_by_id(interest.to_i)
+        end
+        has_interest = false
       end
     end
     @profile.save(:validate => true)

--- a/app/views/profiles/edit.html.erb
+++ b/app/views/profiles/edit.html.erb
@@ -138,7 +138,7 @@
         <div class="form-group">
           <label class="col-md-3 control-label">Graduate Start Term:</label>
           <div class="col-md-8">
-            <%= select_tag 'interested_term', options_for_select(['Fall', 'Spring'], :selected => @profile.interested_term || nil,), include_blank: 'Term of study', class: "form-control" %>
+            <%= select_tag 'interested_term', options_for_select(['Fall', 'Spring', 'Summer', 'Winter'], :selected => @profile.interested_term || nil,), include_blank: 'Term of study', class: "form-control" %>
           </div>
         </div>
 

--- a/app/views/profiles/edit.html.erb
+++ b/app/views/profiles/edit.html.erb
@@ -145,7 +145,7 @@
         <div class="form-group">
           <label class="col-md-3 control-label">Graduate Start Year:</label>
           <div class="col-md-8">
-            <%= select_tag 'interested_year', options_for_select(['2019','2020','2021','2022','2022','2023','2024','2025','2026', '2027','2028','2029'], :selected => @profile.interested_year || nil), include_blank: 'Year of study', :selected_value => @profile.interested_term || nil, class: "form-control" %>
+            <%= select_tag 'interested_year', options_for_select(['2019','2020','2021','2022','2023','2024','2025','2026', '2027','2028','2029'], :selected => @profile.interested_year || nil), include_blank: 'Year of study', :selected_value => @profile.interested_term || nil, class: "form-control" %>
           </div>
         </div>
         <div class="form-group">

--- a/app/views/profiles/edit.html.erb
+++ b/app/views/profiles/edit.html.erb
@@ -145,7 +145,7 @@
         <div class="form-group">
           <label class="col-md-3 control-label">Graduate Start Year:</label>
           <div class="col-md-8">
-            <%= select_tag 'interested_year', options_for_select(['2019','2020','2021','2022','2022','2023','2024','2025','2026', '2027','2028','2029'], :selected => @profile.interested_year || nil), include_blank: 'Term of study', :selected_value => @profile.interested_term || nil, class: "form-control" %>
+            <%= select_tag 'interested_year', options_for_select(['2019','2020','2021','2022','2022','2023','2024','2025','2026', '2027','2028','2029'], :selected => @profile.interested_year || nil), include_blank: 'Year of study', :selected_value => @profile.interested_term || nil, class: "form-control" %>
           </div>
         </div>
         <div class="form-group">

--- a/app/views/profiles/edit.html.erb
+++ b/app/views/profiles/edit.html.erb
@@ -42,7 +42,7 @@
         <div class="form-group">
           <label class="col-md-3 control-label">Gender:</label>
           <div class="col-md-8">
-            <%= select_tag "gender", options_for_select(['Female', 'Male', 'Not Specified']), include_blank: 'Gender', class: "form-control" %>
+            <%= select_tag "gender", options_for_select(['Female', 'Male', 'Not Specified'],  :selected => @profile.gender || nil), include_blank: 'Gender', class: "form-control" %>
             <br>
           </div>
         </div>
@@ -50,7 +50,7 @@
         <div class="form-group">
           <label class="col-md-3 control-label">Citizenship:</label>
           <div class="col-md-8">
-            <%= select_tag "citizenship", options_for_select(Country.all.each.collect{ |u| [u.name, u.id]} ), include_blank: 'Country', class: "form-control"%>
+            <%= select_tag "citizenship", options_for_select(Country.all.each.collect{ |u| [u.name, u.id]}, selected: @profile.country.nil? ? nil: @profile.country_id), include_blank: 'Country', class: "form-control"%>
             <br>
           </div>
         </div>
@@ -58,8 +58,8 @@
         <div class="form-group">
           <label class="col-md-3 control-label">Degree Objective:</label>
           <div class="col-md-8">
-            <%= select_tag "degree_objective_phd", options_for_select(['1', '2', '3', '4', '5']), include_blank: 'Phd', class: "form-control" %>
-            <%= select_tag "degree_objective_master", options_for_select(['1', '2', '3', '4', '5']), include_blank: 'Master', class: "form-control" %>
+            <%= select_tag "degree_objective_phd", options_for_select(['1', '2', '3', '4', '5'],  :selected => @profile.degree_objective_phd || nil), include_blank: 'Phd', class: "form-control" %>
+            <%= select_tag "degree_objective_master", options_for_select(['1', '2', '3', '4', '5'], :selected => @profile.degree_objective_master || nil), include_blank: 'Master', class: "form-control" %>
             <br>
           </div>
         </div>
@@ -132,7 +132,7 @@
         <div class="form-group">
           <label class="col-md-3 control-label">Graduate Start Term:</label>
           <div class="col-md-8">
-            <%= text_area :profile, 'interested_term', class: "form-control", text: @profile.interested_term, id: 'interested_start_term' %>
+            <%= select_tag 'interested_term', options_for_select(['Fall', 'Spring']), include_blank: 'Term of study', :selected_value => @profile.interested_term || nil, class: "form-control" %>
           </div>
         </div>
 
@@ -145,7 +145,7 @@
         <div class="form-group">
           <label class="col-md-3 control-label">Work Experience (Year):</label>
           <div class="col-md-8">
-            <%= select_tag "year_work_exp", options_for_select(['Less than 1 year', '1 - 2 years', '3 - 4 years', '4 - 5 years', '5 - 7 years', '7 - 10 years', '>10 years', 'Not Specified']), include_blank: 'Estimate year of work experience', class: "form-control" %>
+            <%= select_tag "year_work_exp", options_for_select(['Less than 1 year', '1 - 2 years', '3 - 4 years', '4 - 5 years', '5 - 7 years', '7 - 10 years', '>10 years', 'Not Specified'],  :selected => @profile.year_work_exp || nil), include_blank: 'Estimate year of work experience', class: "form-control" %>
             <br>
           </div>
         </div>

--- a/app/views/profiles/edit.html.erb
+++ b/app/views/profiles/edit.html.erb
@@ -66,8 +66,14 @@
 
         <div class="form-group">
           <label class="col-md-3 control-label">Research Interest:</label>
+
           <div class="col-md-8">
-            <%= select_tag :research_interest, options_for_select(ResearchInterest.all.each.collect{ |u| [u.name, u.id]} ), :multiple => true, class: "form-control"%>
+            <% if @profile.research_interests.nil? or @profile.research_interests.empty?%>
+              <input class="form-control" type="text" value="" readonly>
+            <% else %>
+              <input class="form-control" type="text" value="<%= @profile.research_interests.pluck(:name).map(&:inspect).join(', ').gsub(/"/, '') %>" readonly>
+            <% end %>
+            <%= select_tag :research_interest, options_for_select(ResearchInterest.all.each.collect{ |u| [u.name, u.id]}), :multiple => true, class: "form-control"%>
             <br><br>
           </div>
         </div>
@@ -92,7 +98,7 @@
               <br><br>
             </div>
             <div class="col-md-5">
-              <%= select_tag "grading_scale", options_for_select(GradingScaleType.all.each.collect{ |u| [u.grading_scale_name, u.id]} ), include_blank: 'Grading Scale', class: "form-control"%>
+              <%= select_tag "grading_scale", options_for_select(GradingScaleType.all.each.collect{ |u| [u.grading_scale_name, u.id]}, :selected => @profile.grading_scale_type_id ), include_blank: 'Grading Scale', class: "form-control"%>
               <br><br>
             </div>
           </div>
@@ -132,14 +138,14 @@
         <div class="form-group">
           <label class="col-md-3 control-label">Graduate Start Term:</label>
           <div class="col-md-8">
-            <%= select_tag 'interested_term', options_for_select(['Fall', 'Spring']), include_blank: 'Term of study', :selected_value => @profile.interested_term || nil, class: "form-control" %>
+            <%= select_tag 'interested_term', options_for_select(['Fall', 'Spring'], :selected => @profile.interested_term || nil,), include_blank: 'Term of study', class: "form-control" %>
           </div>
         </div>
 
         <div class="form-group">
           <label class="col-md-3 control-label">Graduate Start Year:</label>
           <div class="col-md-8">
-            <%= text_area :profile, 'interested_year', class: "form-control", text: @profile.interested_year, id: 'interested_start_year' %>
+            <%= select_tag 'interested_year', options_for_select(['2019','2020','2021','2022','2022','2023','2024','2025','2026', '2027','2028','2029'], :selected => @profile.interested_year || nil), include_blank: 'Term of study', :selected_value => @profile.interested_term || nil, class: "form-control" %>
           </div>
         </div>
         <div class="form-group">

--- a/app/views/profiles/show.html.erb
+++ b/app/views/profiles/show.html.erb
@@ -65,9 +65,7 @@
             <% if @profile.research_interests.nil? or @profile.research_interests.empty?%>
               <input class="form-control" type="text" value="" readonly>
             <% else %>
-              <% @profile.research_interests.each  do |interest|%>
-                <input class="form-control" type="text" value="<%= interest.name %>" readonly>
-              <% end %>
+                <input class="form-control" type="text" value="<%= @profile.research_interests.pluck(:name).map(&:inspect).join(', ').gsub(/"/, '') %>" readonly>
             <% end %>
           </div>
         </div>

--- a/app/views/profiles/show.html.erb
+++ b/app/views/profiles/show.html.erb
@@ -26,15 +26,9 @@
 
       <form class="form-horizontal" role="form">
         <div class="form-group">
-          <label class="col-md-3 control-label">First name:</label>
+          <label class="col-md-3 control-label">Name:</label>
           <div class="col-md-8">
-            <input class="form-control" type="text" value="<%= @current_student.first_name %>" readonly>
-          </div>
-        </div>
-        <div class="form-group">
-          <label class="col-md-3 control-label">Last name:</label>
-          <div class="col-md-8">
-            <input class="form-control" type="text" value="<%= @current_student.last_name %>" readonly>
+            <input class="form-control" type="text" value="<%= @current_student.first_name + ' ' + @current_student.last_name%>" readonly>
           </div>
         </div>
         <div class="form-group">

--- a/features/step_definitions/students_steps.rb
+++ b/features/step_definitions/students_steps.rb
@@ -189,8 +189,8 @@ Then /^I can update my (.*?)$/ do |field|
     current_student.current_profile.gre_verbal.should eq(158)
     current_student.current_profile.gre_quant.should eq(162)
   when 'intended start term'
-    fill_in 'interested_start_term', with: 'Spring'
-    fill_in 'interested_start_year', with: '2022'
+    select('Spring', from: 'interested_term')
+    select('2022', from:'interested_year')
     click_button 'Save Changes'
     current_student.current_profile.interested_term.should eq('Spring')
     current_student.current_profile.interested_year.should eq(2022)


### PR DESCRIPTION
This PR changes the start year and month on edit page into a dropdown to make it easier to validate data on background

## Type of change
- [x] Front end change

## Code coverage
96.7%

## Screenshot (if any change in front end)
![image](https://user-images.githubusercontent.com/12748234/54858219-86813000-4cd1-11e9-9b3f-a95d5efd5031.png)

