### PR TITLE
Allow students to add only one university for selected term and year

### DIFF
--- a/app/controllers/profiles_controller.rb
+++ b/app/controllers/profiles_controller.rb
@@ -147,7 +147,7 @@ class ProfilesController < ApplicationController
       flash[:notice] = 'Please enter all the fields'
     else
       @university = University.find_by_university_name(params[:univ_name])
-      @applications_new = Application.where(profile_id:profile_id, university_id: @university.id)
+      @applications_new = Application.where(profile_id:profile_id, university_id: @university.id, term: params[:term],year: params[:year])
       if @applications_new.blank?
         @applications = Application.add_school!(profile_id,@university.id ,params[:sel_opt], params[:datepicker],params[:term],params[:year])
         if @applications
@@ -156,7 +156,7 @@ class ProfilesController < ApplicationController
           flash[:notice] = 'Error while saving application to database'
         end
       else
-        flash[:notice] = 'University is already present. Please add a new one'
+        flash[:notice] = 'University is already present for the selected term and year. Please add a new one'
       end
     end
     @applications = Application.where(profile_id: profile_id)

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -95,14 +95,18 @@ ActiveRecord::Schema.define(version: 20190401015502) do
 
   create_table "faculty_evaluations", force: :cascade do |t|
     t.integer  "faculty_id"
+    t.integer  "profile_id"
+    t.integer  "application_id"
     t.integer  "score"
     t.integer  "ee_background"
     t.string   "comment"
-    t.datetime "created_at",    null: false
-    t.datetime "updated_at",    null: false
+    t.datetime "created_at",     null: false
+    t.datetime "updated_at",     null: false
   end
 
+  add_index "faculty_evaluations", ["application_id"], name: "index_faculty_evaluations_on_application_id"
   add_index "faculty_evaluations", ["faculty_id"], name: "index_faculty_evaluations_on_faculty_id"
+  add_index "faculty_evaluations", ["profile_id"], name: "index_faculty_evaluations_on_profile_id"
 
   create_table "grading_scale_types", force: :cascade do |t|
     t.string   "grading_scale_name"

--- a/spec/controllers/profiles_controller_spec.rb
+++ b/spec/controllers/profiles_controller_spec.rb
@@ -63,7 +63,7 @@ describe ProfilesController do
   end
   describe 'show list of schools' do
     it 'should show list of schools added by a student' do
-      application = Application.new(id: 1, profile_id: 1, university_id: 1, applied: 't', applied_date: '2019-01-02', admitted: 't', admitted_date: '2019-03-05', rejected: '', rejected_date:'')
+      application = Application.new(id: 1, profile_id: 1, university_id: 1, applied: 't', applied_date: '2019-01-02', admitted: 't', admitted_date: '2019-03-05', rejected: '', rejected_date:'',:term => 'Fall', :year => '2020')
       application.save
       expect(Application).to receive(:where).with(profile_id: '1').and_return(application)
       get :showschools, {:id => '1'}
@@ -79,9 +79,9 @@ describe ProfilesController do
       controller.instance_eval {@profile = @mock_profile}
       @university = University.new(id: 1, rank: 1, university_name: 'Stanford University')
       @university.save
-      @application_new = Application.new(:id => 2, :profile_id=> 1, :university_id => 1, :applied=>'t', :applied_date => '2019-03-06', :admitted=>'t',:admitted_date=>'2019-04-23',:rejected=>'',:rejected_date=>'')
+      @application_new = Application.new(:id => 2, :profile_id=> 1, :university_id => 1, :applied=>'t', :applied_date => '2019-03-06', :admitted=>'t',:admitted_date=>'2019-04-23',:rejected=>'',:rejected_date=>'', :term => 'Fall', :year => '2020')
       @application_new.save
-      @application = Application.new(:id => 1, :profile_id=> 1, :university_id => 1, :applied=>'t', :applied_date => '2019-03-06', :admitted=>'',:admitted_date=>'',:rejected=>'',:rejected_date=>'')
+      @application = Application.new(:id => 1, :profile_id=> 1, :university_id => 1, :applied=>'t', :applied_date => '2019-03-06', :admitted=>'',:admitted_date=>'',:rejected=>'',:rejected_date=>'',:term => 'Fall', :year => '2020')
       @application.save
       format = double("format")
       format.should_receive(:js).and_return("location.reload();")
@@ -115,7 +115,7 @@ describe ProfilesController do
       expect(University).to receive(:find_by_university_name).with("Stanford University").and_return(@university)
       allow(Application).to receive(:where).and_return(@application_new)
       post :addschools, {"univ_name"=>"Stanford University", "datepicker"=>"03/06/2019", "sel_opt"=>"Applied - Accepted", "term"=>"Fall", "year"=>"2020"}
-      expect(flash[:notice]).to eq('University is already present. Please add a new one')
+      expect(flash[:notice]).to eq('University is already present for the selected term and year. Please add a new one')
     end
     it 'should render interested school template' do
       post :addschools, {"univ_name"=>"Stanford University", "datepicker"=>"03/06/2019", "sel_opt"=>"Applied - Accepted", "term"=>"Fall", "year"=>"2020"}


### PR DESCRIPTION
Currently, students cannot add a university for different terms and year. This PR fixes this issue to allow them to add a university for different term and year. 

Also, master database schema doesn't reflect correct changes for faculty evaluation table(profile_id and application_id fields are missing). Hence, this PR shows changes in schema.rb file as well.

## Issue Related
#203 

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Code coverage
95.95%

## Screenshot (if any change in front end)
![g1](https://user-images.githubusercontent.com/42561372/55634814-dc9bac00-5784-11e9-9e0b-0685eb77f9c4.JPG)

![G2](https://user-images.githubusercontent.com/42561372/55634825-e1606000-5784-11e9-869e-9855d4c1dc2b.JPG)

