### PR TITLE
Added error message when score/ee_background is empty for evaluation

### DIFF
--- a/app/controllers/faculty_evaluations_controller.rb
+++ b/app/controllers/faculty_evaluations_controller.rb
@@ -4,22 +4,21 @@ class FacultyEvaluationsController < ApplicationController
   end
   def create
     id = params[:id]
-    score = nil
-    ee_background = nil
     comment = nil
-    if !params[:application_score].blank?
+    if params[:application_score].blank? || params[:ee_background].blank?
+      flash[:notice] = 'Score/EE Background cannot be blank. Please select the fields.'
+      redirect_to faculty_evaluation_path(id)
+    else
       score = params[:application_score].to_i
-    end
-    if !params[:ee_background].blank?
       ee_background = params[:ee_background].to_i
+      if !params[:comment].blank?
+         comment = params[:comment]
+      end
+      @faculty_evaluation = FacultyEvaluation.create(faculty_id: current_faculty.id, application_id: id, score: score, ee_background: ee_background, comment: comment)
+      flash[:notice] = 'Your evaluation has been submitted!'
+      redirect_to fViewProfile_profiles_path(id)
     end
-    if !params[:comment].blank?
-      comment = params[:comment]
-    end
-    @student = Application.find_by_id(id.to_i).profile.student
-    @faculty_evaluation = FacultyEvaluation.create(faculty_id: current_faculty.id, application_id: id, score: score, ee_background: ee_background, comment: comment)
-    flash[:notice] = 'Your evaluation has been submitted!'
-    redirect_to fViewProfile_profiles_path(id)
+
   end
 
   def index

--- a/app/views/faculty_evaluations/index.html.erb
+++ b/app/views/faculty_evaluations/index.html.erb
@@ -12,8 +12,10 @@
   <br>
   <br>
   <div id ='evaluationTable'>
-  <table id='facultyEvaluationTable' class="table table-striped table-bordered">
-    <thead>
+    <h2>My Evaluations</h2>
+    <br>
+    <table id='facultyEvaluationTable' class="table table-striped table-bordered">
+      <thead>
     <tr>
       <th>Student Name</th>
       <th>Email</th>
@@ -40,4 +42,4 @@
     </tbody>
   </table>
   </div>
-<%end %>
+  <%end %>

--- a/app/views/faculty_evaluations/showEvaluations.html.erb
+++ b/app/views/faculty_evaluations/showEvaluations.html.erb
@@ -12,6 +12,8 @@
   <br>
   <br>
   <div id ='fevaluationTable' class="form-group">
+    <h2>Other Evaluations</h2>
+    <br>
     <table id='facultyOEvaluationTable' class="table table-striped table-bordered">
       <thead>
       <tr>

--- a/features/SubmitEvaluationByFaculty.feature
+++ b/features/SubmitEvaluationByFaculty.feature
@@ -102,4 +102,19 @@ Feature: Faculty can submit evaluations for students
     And I click on Back button
     Then I should be on application filtering page
 
+  Scenario: Faculty should get error message when score field is empty
+    When I log_in as a faculty as Alice
+    And I click on Robin Hood link
+    And I click on Add Evaluation button
+    And I do not fill in score for the student and click on submit
+    Then I should get an error message
+
+  Scenario: Faculty should get error message when ee background field is empty
+    When I log_in as a faculty as Alice
+    And I click on Robin Hood link
+    And I click on Add Evaluation button
+    And I do not fill in ee_background for the student and click on submit
+    Then I should get an error message
+
+
 

--- a/features/step_definitions/faculty_evaluation_steps.rb
+++ b/features/step_definitions/faculty_evaluation_steps.rb
@@ -98,3 +98,18 @@ Then(/^I should not see Add Evaluation button$/) do
   expect(page).not_to have_selector "#addevaluation"
   page.should have_content(' Evaluation submitted on 04-07-2018')
 end
+
+And(/^I do not fill in (.*?) for the student and click on submit$/) do |option|
+  case option
+  when 'score'
+    select('1 - Has EE background -', from:'ee_background')
+  when 'ee_background'
+    select('4 - Good +', from: 'application_score')
+  end
+  fill_in 'comment', with: 'Good Profile'
+  click_on 'Submit'
+end
+
+Then(/^I should get an error message$/) do
+  page.should have_content('Score/EE Background cannot be blank. Please select the fields.')
+end

--- a/spec/controllers/faculty_evaluations_controller_spec.rb
+++ b/spec/controllers/faculty_evaluations_controller_spec.rb
@@ -39,16 +39,16 @@ describe FacultyEvaluationsController do
       get :create, {"utf8"=>"✓", "application_score"=>"5 - Excellent", "ee_background"=>"1 - Has EE background -", "comment"=>"test comment", "commit"=>"Submit", "id"=>"1"}
     end
 
-    it 'should create evaluation of student when score is not present' do
-      mock_evaluation = {id:1 ,faculty_id: 1, application_id: "1", score: nil, ee_background: 1, comment: "test comment"}
-      expect(FacultyEvaluation).to receive(:create).with(faculty_id: 1, application_id: "1",score: nil, ee_background: 1, comment: "test comment").and_return(mock_evaluation)
+    it 'should flash notice when score is not present' do
       get :create, {"utf8"=>"✓", "application_score"=>"", "ee_background"=>"1 - Has EE background -", "comment"=>"test comment", "commit"=>"Submit", "id"=>"1"}
+      expect(flash[:notice]).to eq('Score/EE Background cannot be blank. Please select the fields.')
+      response.should redirect_to(faculty_evaluation_path)
     end
 
-    it 'should create evaluation of student when ee background is not present' do
-      mock_evaluation = {id:1 ,faculty_id: 1, application_id: "1", score: 4, ee_background: nil, comment: "test comment"}
-      expect(FacultyEvaluation).to receive(:create).with(faculty_id: 1, application_id: "1",score: 4, ee_background: nil, comment: "test comment").and_return(mock_evaluation)
+    it 'should flash notice when ee background is not present' do
       get :create, {"utf8"=>"✓", "application_score"=>"4", "ee_background"=>"", "comment"=>"test comment", "commit"=>"Submit", "id"=>"1"}
+      expect(flash[:notice]).to eq('Score/EE Background cannot be blank. Please select the fields.')
+      response.should redirect_to(faculty_evaluation_path)
     end
 
     it 'should create evaluation of student when comment is not present' do


### PR DESCRIPTION
This PR adds error message when score/ee_background is empty when faculty submits evaluation.
Also, headers are added on view evaluations page.

## Issue Related

## Type of change
- [x] New feature (non-breaking change which adds functionality)

## Code coverage
98.45%

## Screenshot (if any change in front end)

![f1](https://user-images.githubusercontent.com/42561372/56328419-8ba49400-6144-11e9-852b-ab147c059965.JPG)

![f2](https://user-images.githubusercontent.com/42561372/56328554-1ab1ac00-6145-11e9-83aa-39044a69fd8d.JPG)
